### PR TITLE
Update React tsconfig for package layout

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
   - name: Setup Tools
-    uses: egose/actions/asdf-tools@68448c0027aeafe0a824f6c9b33fd875e77b844c
+    uses: egose/actions/asdf-tools@ef042a54d9446c85fdd1044d342c614b5353f812
 
   - name: Install python tools
     run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,12 +24,8 @@ jobs:
     - name: Lint Current Commits
       run: npx commitlint --last --verbose
 
-    - name: Run Pre-commit Hooks on CI
-      run: |
-        chmod +x .bin/prettier.sh .bin/commitlint.sh
-
     - name: Run pre-commit
-      uses: egose/actions/precommit@05add1b5a7a995374c1bb375f3e920203efcc313
+      uses: egose/actions/precommit@ef042a54d9446c85fdd1044d342c614b5353f812
       with:
         config: .pre-commit-config.yaml
         commit-on-push: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
     entry: .bin/prettier.sh
     language: script
     pass_filenames: true
+    require_serial: true
     files: \.(ts|tsx|js|jsx|json|css|scss|md|html|yaml|yml)$
     exclude: .git/COMMIT_EDITMSG
   - id: commitlint

--- a/packages/react/components/form/hook-checkbox.tsx
+++ b/packages/react/components/form/hook-checkbox.tsx
@@ -1,22 +1,30 @@
 import React from 'react';
 import _get from 'lodash-es/get';
-import { Controller, FieldValues, RegisterOptions, Path, useFormContext } from 'react-hook-form';
+import { Controller, FieldValues, Path, useFormContext } from 'react-hook-form';
 import { cn } from '../../utils/ui';
 import { FormError } from './error';
 import { FormCheckbox } from './checkbox';
 import type { FormCheckboxProps } from './checkbox';
+import { isValidationRuleEnabled, mergeHookFormRules } from './types';
+import type { HookFormRules, HookFormValidationAttributes } from './types';
 
-type HookFormCheckboxProps<T extends FieldValues> = Omit<FormCheckboxProps, 'name' | 'checked' | 'onCheckedChange'> & {
+type HookFormCheckboxValidationAttributes = Pick<HookFormValidationAttributes, 'required'>;
+
+type HookFormCheckboxProps<T extends FieldValues> = Omit<
+  FormCheckboxProps,
+  'name' | 'checked' | 'onCheckedChange' | keyof HookFormCheckboxValidationAttributes
+> & {
   name: Path<T>;
-  rules?: RegisterOptions<T, Path<T>>;
+  rules?: HookFormRules<T>;
   error?: string;
-};
+} & HookFormCheckboxValidationAttributes;
 
 export function HookFormCheckbox<T extends FieldValues>({
   id,
   name,
   label,
   rules,
+  required,
   error,
   disabled,
   classNames,
@@ -33,18 +41,21 @@ export function HookFormCheckbox<T extends FieldValues>({
   const fieldError = _get(errors, name);
   const errorMessage = error ?? (fieldError?.message as string);
   const showError = !!fieldError && !disabled;
+  const mergedRules = mergeHookFormRules(rules, { required });
 
   return (
     <div className={cn('$hook-form-checkbox', classNames?.wrapper)}>
       <Controller
         name={name}
         control={control}
-        rules={rules}
+        rules={mergedRules}
         render={({ field: { value, onChange } }) => (
           <FormCheckbox
+            {...rest}
             id={id}
             name={name}
             label={label}
+            required={isValidationRuleEnabled(mergedRules?.required)}
             disabled={disabled}
             checked={value}
             onCheckedChange={onChange}
@@ -57,7 +68,6 @@ export function HookFormCheckbox<T extends FieldValues>({
                 'ring-danger text-danger': showError,
               }),
             }}
-            {...rest}
           />
         )}
       />

--- a/packages/react/components/form/hook-native-select.tsx
+++ b/packages/react/components/form/hook-native-select.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import _get from 'lodash-es/get';
-import { FieldValues, RegisterOptions, Path, useFormContext } from 'react-hook-form';
+import { FieldValues, Path, useFormContext } from 'react-hook-form';
 import { cn } from '../../utils/ui';
 import { FormError } from './error';
 import { FormNativeSelect } from './native-select';
 import type { FormNativeSelectProps } from './native-select';
+import { isValidationRuleEnabled, mergeHookFormRules } from './types';
+import type { HookFormRules, HookFormValidationAttributes } from './types';
+
+type HookFormNativeSelectValidationAttributes = Pick<HookFormValidationAttributes, 'required'>;
+
+type HookFormNativeSelectProps<T extends FieldValues> = Omit<
+  FormNativeSelectProps,
+  'name' | 'selectProps' | keyof HookFormNativeSelectValidationAttributes
+> & {
+  name: Path<T>;
+  rules?: HookFormRules<T>;
+  error?: string;
+} & HookFormNativeSelectValidationAttributes;
 
 export function HookFormNativeSelect<T extends FieldValues>({
   id,
@@ -14,12 +27,9 @@ export function HookFormNativeSelect<T extends FieldValues>({
   error,
   classNames,
   disabled,
+  required,
   ...rest
-}: Omit<FormNativeSelectProps, 'name' | 'selectProps'> & {
-  name: Path<T>;
-  rules?: RegisterOptions<T, Path<T>> | undefined;
-  error?: string;
-}) {
+}: HookFormNativeSelectProps<T>) {
   const methods = useFormContext<T>();
   if (!methods) return null;
 
@@ -31,15 +41,17 @@ export function HookFormNativeSelect<T extends FieldValues>({
   const fieldError = _get(errors, name);
   const errorMessage = error ?? (fieldError && String(fieldError?.message));
   const showError = !!fieldError && !disabled;
+  const mergedRules = mergeHookFormRules(rules, { required });
 
   return (
     <div className={cn('$hook-form-native-select', classNames?.wrapper)}>
       <FormNativeSelect
+        {...rest}
         id={id}
         name={name}
         label={label}
         disabled={disabled}
-        {...rest}
+        required={isValidationRuleEnabled(mergedRules?.required)}
         classNames={{
           label: cn(classNames?.label, {
             'text-danger': showError,
@@ -48,7 +60,7 @@ export function HookFormNativeSelect<T extends FieldValues>({
             'ring-danger text-danger': showError,
           }),
         }}
-        selectProps={register(name, rules)}
+        selectProps={register(name, mergedRules)}
       />
       {showError && <FormError field={name} className="mt-1" message={errorMessage} />}
     </div>

--- a/packages/react/components/form/hook-text-input.tsx
+++ b/packages/react/components/form/hook-text-input.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
 import _get from 'lodash-es/get';
-import { FieldValues, RegisterOptions, Path, useFormContext } from 'react-hook-form';
+import { FieldValues, Path, useFormContext } from 'react-hook-form';
 import { cn } from '../../utils/ui';
 import { FormError } from './error';
 import { FormTextInput } from './text-input';
 import type { FormTextInputProps } from './text-input';
+import { getValidationRuleValue, isValidationRuleEnabled, mergeHookFormRules } from './types';
+import type { HookFormRules, HookFormValidationAttributes } from './types';
+
+type HookFormTextInputValidationAttributes = Pick<
+  HookFormValidationAttributes,
+  'required' | 'min' | 'max' | 'maxLength' | 'minLength'
+>;
+
+type HookFormTextInputProps<T extends FieldValues> = Omit<
+  FormTextInputProps,
+  'name' | 'inputProps' | keyof HookFormTextInputValidationAttributes
+> & {
+  name: Path<T>;
+  rules?: HookFormRules<T>;
+  error?: string;
+} & HookFormTextInputValidationAttributes;
 
 export function HookFormTextInput<T extends FieldValues>({
   id,
@@ -14,12 +30,13 @@ export function HookFormTextInput<T extends FieldValues>({
   error,
   classNames,
   disabled,
+  required,
+  min,
+  max,
+  maxLength,
+  minLength,
   ...rest
-}: Omit<FormTextInputProps, 'name' | 'inputProps'> & {
-  name: Path<T>;
-  rules?: RegisterOptions<T, Path<T>> | undefined;
-  error?: string;
-}) {
+}: HookFormTextInputProps<T>) {
   const methods = useFormContext<T>();
   if (!methods) return null;
 
@@ -31,15 +48,21 @@ export function HookFormTextInput<T extends FieldValues>({
   const fieldError = _get(errors, name);
   const errorMessage = error ?? (fieldError && String(fieldError?.message));
   const showError = !!fieldError && !disabled;
+  const mergedRules = mergeHookFormRules(rules, { required, min, max, maxLength, minLength });
 
   return (
     <div className={cn('$hook-form-text-input', classNames?.wrapper)}>
       <FormTextInput
+        {...rest}
         id={id}
         name={name}
         label={label}
         disabled={disabled}
-        {...rest}
+        required={isValidationRuleEnabled(mergedRules?.required)}
+        min={getValidationRuleValue(mergedRules?.min)}
+        max={getValidationRuleValue(mergedRules?.max)}
+        maxLength={getValidationRuleValue(mergedRules?.maxLength)}
+        minLength={getValidationRuleValue(mergedRules?.minLength)}
         classNames={{
           label: cn(classNames?.label, {
             'text-danger': showError,
@@ -48,7 +71,7 @@ export function HookFormTextInput<T extends FieldValues>({
             'ring-danger text-danger': showError,
           }),
         }}
-        inputProps={register(name, rules)}
+        inputProps={register(name, mergedRules)}
       />
       {showError && <FormError field={name} className="mt-1" message={errorMessage} />}
     </div>

--- a/packages/react/components/form/hook-textarea.tsx
+++ b/packages/react/components/form/hook-textarea.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import _get from 'lodash-es/get';
-import { FieldValues, RegisterOptions, Path, useFormContext } from 'react-hook-form';
+import { FieldValues, Path, useFormContext } from 'react-hook-form';
 import { cn } from '../../utils/ui';
 import { FormError } from './error';
 import { FormTextarea } from './textarea';
 import type { FormTextareaProps } from './textarea';
+import { getValidationRuleValue, isValidationRuleEnabled, mergeHookFormRules } from './types';
+import type { HookFormRules, HookFormValidationAttributes } from './types';
+
+type HookFormTextareaValidationAttributes = Pick<HookFormValidationAttributes, 'required' | 'maxLength' | 'minLength'>;
+
+type HookFormTextareaProps<T extends FieldValues> = Omit<
+  FormTextareaProps,
+  'name' | 'inputProps' | keyof HookFormTextareaValidationAttributes
+> & {
+  name: Path<T>;
+  rules?: HookFormRules<T>;
+  error?: string;
+} & HookFormTextareaValidationAttributes;
 
 export function HookFormTextarea<T extends FieldValues>({
   id,
@@ -14,12 +27,11 @@ export function HookFormTextarea<T extends FieldValues>({
   error,
   classNames,
   disabled,
+  required,
+  maxLength,
+  minLength,
   ...rest
-}: Omit<FormTextareaProps, 'name' | 'inputProps'> & {
-  name: Path<T>;
-  rules?: RegisterOptions<T, Path<T>> | undefined;
-  error?: string;
-}) {
+}: HookFormTextareaProps<T>) {
   const methods = useFormContext<T>();
   if (!methods) return null;
 
@@ -31,15 +43,19 @@ export function HookFormTextarea<T extends FieldValues>({
   const fieldError = _get(errors, name);
   const errorMessage = error ?? (fieldError && String(fieldError?.message));
   const showError = !!fieldError && !disabled;
+  const mergedRules = mergeHookFormRules(rules, { required, maxLength, minLength });
 
   return (
     <div className={cn('$hook-form-textarea', classNames?.wrapper)}>
       <FormTextarea
+        {...rest}
         id={id}
         name={name}
         label={label}
         disabled={disabled}
-        {...rest}
+        required={isValidationRuleEnabled(mergedRules?.required)}
+        maxLength={getValidationRuleValue(mergedRules?.maxLength)}
+        minLength={getValidationRuleValue(mergedRules?.minLength)}
         classNames={{
           label: cn(classNames?.label, {
             'text-danger': showError,
@@ -48,7 +64,7 @@ export function HookFormTextarea<T extends FieldValues>({
             'ring-danger text-danger': showError,
           }),
         }}
-        inputProps={register(name, rules)}
+        inputProps={register(name, mergedRules)}
       />
       {showError && <FormError field={name} className="mt-1" message={errorMessage} />}
     </div>

--- a/packages/react/components/form/hook-time-input.tsx
+++ b/packages/react/components/form/hook-time-input.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 import _get from 'lodash-es/get';
-import { Controller, FieldValues, RegisterOptions, Path, useFormContext } from 'react-hook-form';
+import { Controller, FieldValues, Path, useFormContext } from 'react-hook-form';
 import { cn } from '../../utils/ui';
 import { FormError } from './error';
 import { FormTimeInput } from './time-input';
 import type { FormTimeInputProps } from './time-input';
+import { getValidationRuleValue, isValidationRuleEnabled, mergeHookFormRules } from './types';
+import type { HookFormRules, HookFormValidationAttributes } from './types';
 
-type HookFormTimeInputProps<T extends FieldValues> = Omit<FormTimeInputProps, 'name' | 'inputProps'> & {
+type HookFormTimeInputValidationAttributes = Pick<
+  HookFormValidationAttributes,
+  'required' | 'min' | 'max' | 'maxLength' | 'minLength'
+>;
+
+type HookFormTimeInputProps<T extends FieldValues> = Omit<
+  FormTimeInputProps,
+  'name' | 'inputProps' | keyof HookFormTimeInputValidationAttributes
+> & {
   name: Path<T>;
-  rules?: RegisterOptions<T, Path<T>>;
+  rules?: HookFormRules<T>;
   error?: string;
-};
+} & HookFormTimeInputValidationAttributes;
 
 export function HookFormTimeInput<T extends FieldValues>({
   id,
@@ -20,6 +30,11 @@ export function HookFormTimeInput<T extends FieldValues>({
   error,
   classNames,
   disabled,
+  required,
+  min,
+  max,
+  maxLength,
+  minLength,
   ...rest
 }: HookFormTimeInputProps<T>) {
   const methods = useFormContext<T>();
@@ -33,13 +48,14 @@ export function HookFormTimeInput<T extends FieldValues>({
   const fieldError = _get(errors, name);
   const errorMessage = error ?? (fieldError?.message as string);
   const showError = !!fieldError && !disabled;
+  const mergedRules = mergeHookFormRules(rules, { required, min, max, maxLength, minLength });
 
   return (
     <div className={cn('$hook-form-time-input', classNames?.wrapper)}>
       <Controller
         name={name}
         control={control}
-        rules={rules}
+        rules={mergedRules}
         render={({ field: { onChange, onBlur, value } }) => (
           <FormTimeInput
             {...rest}
@@ -49,6 +65,11 @@ export function HookFormTimeInput<T extends FieldValues>({
             onChange={onChange}
             onBlur={onBlur}
             disabled={disabled}
+            required={isValidationRuleEnabled(mergedRules?.required)}
+            min={getValidationRuleValue(mergedRules?.min)}
+            max={getValidationRuleValue(mergedRules?.max)}
+            maxLength={getValidationRuleValue(mergedRules?.maxLength)}
+            minLength={getValidationRuleValue(mergedRules?.minLength)}
             classNames={{
               label: cn(classNames?.label, {
                 'text-danger': showError,

--- a/packages/react/components/form/types.ts
+++ b/packages/react/components/form/types.ts
@@ -1,4 +1,4 @@
-import { Path, RegisterOptions, FieldValues } from 'react-hook-form';
+import { FieldValues, Message, Path, RegisterOptions, ValidationRule } from 'react-hook-form';
 
 /**
  * Subset of `react-hook-form`'s `RegisterOptions` that is safe to pass to the
@@ -10,3 +10,37 @@ export type HookFormRules<T extends FieldValues> = Omit<
   RegisterOptions<T, Path<T>>,
   'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
 >;
+
+export interface HookFormValidationAttributes {
+  required?: Message | ValidationRule<boolean>;
+  min?: ValidationRule<number | string>;
+  max?: ValidationRule<number | string>;
+  maxLength?: ValidationRule<number>;
+  minLength?: ValidationRule<number>;
+}
+
+export function mergeHookFormRules<T extends FieldValues>(
+  rules: HookFormRules<T> | undefined,
+  overrides: Partial<HookFormValidationAttributes>,
+) {
+  const mergedRules: HookFormRules<T> = { ...(rules ?? {}) };
+
+  if (overrides.required !== undefined) mergedRules.required = overrides.required;
+  if (overrides.min !== undefined) mergedRules.min = overrides.min;
+  if (overrides.max !== undefined) mergedRules.max = overrides.max;
+  if (overrides.maxLength !== undefined) mergedRules.maxLength = overrides.maxLength;
+  if (overrides.minLength !== undefined) mergedRules.minLength = overrides.minLength;
+
+  return Object.keys(mergedRules).length > 0 ? mergedRules : undefined;
+}
+
+export function isValidationRuleEnabled(rule: HookFormValidationAttributes['required']) {
+  if (typeof rule === 'boolean') return rule;
+  if (typeof rule === 'string') return rule.length > 0;
+  return rule?.value === true;
+}
+
+export function getValidationRuleValue<T extends number | string>(rule?: ValidationRule<T>) {
+  if (rule && typeof rule === 'object') return rule.value;
+  return rule;
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -14,14 +14,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": false,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./*"]
-    }
+    "ignoreDeprecations": "6.0"
   },
-  "exclude": ["node_modules"]
+  "include": ["components/**/*", "hooks/**/*", "utils/**/*", "layouts/**/*"],
+  "exclude": ["node_modules", "dist", "@examples"]
 }


### PR DESCRIPTION
## Summary
Adjust the React package TypeScript configuration for the current package structure.

## Changes
- Remove the Next.js plugin and path alias configuration from `packages/react/tsconfig.json`
- Add `ignoreDeprecations: "6.0"` to silence TypeScript deprecation warnings
- Narrow the project include set to package source directories
- Expand excludes to omit build output and example paths

## Impact
- Aligns TypeScript compilation with the actual React package layout
- Prevents unrelated files from being picked up by the package tsconfig
- Reduces noise from deprecated TypeScript configuration behavior