### PR TITLE
Increase commit scope length limit

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -32,7 +32,7 @@ const Configuration = {
     ],
     'scope-empty': [Severity.OFF],
     'scope-min-length': [Severity.ERROR, Option.ALWAYS, 2],
-    'scope-max-length': [Severity.ERROR, Option.ALWAYS, 10],
+    'scope-max-length': [Severity.ERROR, Option.ALWAYS, 12],
   },
   /*
    * Array of functions that return true if commitlint should ignore the given message.


### PR DESCRIPTION
### Summary
Adjust the commitlint configuration to allow slightly longer scopes.

### Changes
- Increased `scope-max-length` from `10` to `12` in `commitlint.config.mjs`.

### Notes
- This is a small configuration-only change.
- No runtime behavior is affected beyond commit message validation.