### PR TITLE
Add top menu support to the simple layout

### DIFF
--- a/packages/angular/@examples/standard/src/app/app.html
+++ b/packages/angular/@examples/standard/src/app/app.html
@@ -4,6 +4,8 @@
     [sidebarTitle]="'Egose Menu'"
     [sidebarContent]="sidebarContent"
     [leftMenus]="leftMenus"
+    [leftMenuGroups]="leftMenuGroups"
+    [topMenus]="topMenus"
     [rightMenus]="rightMenus"
     [userMenus]="menus"
     [userMenuTrigger]="userMenuTrigger"

--- a/packages/angular/@examples/standard/src/app/app.ts
+++ b/packages/angular/@examples/standard/src/app/app.ts
@@ -2,23 +2,124 @@ import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import {
   lucideCircleHelp,
-  lucideCirclePlus,
   lucideCircleUser,
-  lucideCode,
   lucideCog,
   lucideGithub,
   lucideKeyboard,
   lucideLayers,
   lucideLogOut,
-  lucideMail,
-  lucideMessageSquare,
   lucidePlus,
-  lucideSmile,
   lucideUser,
 } from '@ng-icons/lucide';
-import { EgLayoutSimple, MenuItem } from '@egose/shadcn-theme-ng/layout-simple';
+import { EgLayoutSimple, MenuItem, MenuGroup } from '@egose/shadcn-theme-ng/layout-simple';
 
 type Country = { name: string; code: string; flag: string };
+
+// All 70 component demos, grouped by their natural category (mirrors the sidebar in components.ts).
+const COMPONENT_GROUPS: MenuGroup[] = [
+  {
+    label: 'Existing',
+    items: [
+      { label: 'Button', link: '/components/button' },
+      { label: 'Badge', link: '/components/badge' },
+      { label: 'Icon', link: '/components/icon' },
+      { label: 'Alert', link: '/components/alert' },
+      { label: 'Accordion', link: '/components/accordion' },
+      { label: 'Spinner', link: '/components/spinner' },
+      { label: 'Form Field', link: '/components/form-field' },
+    ],
+  },
+  {
+    label: 'Buttons & Indicators',
+    items: [
+      { label: 'Button Group', link: '/components/button-group' },
+      { label: 'Toggle', link: '/components/toggle' },
+      { label: 'Toggle Group', link: '/components/toggle-group' },
+      { label: 'Switch', link: '/components/switch' },
+    ],
+  },
+  {
+    label: 'Forms & Inputs',
+    items: [
+      { label: 'Input', link: '/components/input' },
+      { label: 'Input Group', link: '/components/input-group' },
+      { label: 'Input OTP', link: '/components/input-otp' },
+      { label: 'Textarea', link: '/components/textarea' },
+      { label: 'Checkbox', link: '/components/checkbox' },
+      { label: 'Radio Group', link: '/components/radio-group' },
+      { label: 'Select', link: '/components/select' },
+      { label: 'Native Select', link: '/components/native-select' },
+      { label: 'Slider', link: '/components/slider' },
+      { label: 'Label', link: '/components/label' },
+      { label: 'Combobox', link: '/components/combobox' },
+      { label: 'Autocomplete', link: '/components/autocomplete' },
+      { label: 'Date Picker', link: '/components/date-picker' },
+      { label: 'Calendar', link: '/components/calendar' },
+      { label: 'Field', link: '/components/field' },
+      { label: 'Form Checkbox', link: '/components/form-checkbox' },
+      { label: 'Form Date Picker', link: '/components/form-date-picker' },
+      { label: 'Form Field Simple', link: '/components/form-field-simple' },
+      { label: 'Form Searchable Multiselect', link: '/components/form-searchable-multiselect' },
+      { label: 'Form Select', link: '/components/form-select' },
+      { label: 'Form Text Input', link: '/components/form-text-input' },
+      { label: 'Form Textarea', link: '/components/form-textarea' },
+    ],
+  },
+  {
+    label: 'Overlays',
+    items: [
+      { label: 'Alert Dialog', link: '/components/alert-dialog' },
+      { label: 'Dialog', link: '/components/dialog' },
+      { label: 'Drawer', link: '/components/drawer' },
+      { label: 'Sheet', link: '/components/sheet' },
+      { label: 'Popover', link: '/components/popover' },
+      { label: 'Hover Card', link: '/components/hover-card' },
+      { label: 'Tooltip', link: '/components/tooltip' },
+      { label: 'Dropdown Menu', link: '/components/dropdown-menu' },
+      { label: 'Context Menu', link: '/components/context-menu' },
+      { label: 'Menubar', link: '/components/menubar' },
+      { label: 'Command', link: '/components/command' },
+      { label: 'Confirmation Dialog', link: '/components/confirmation-dialog' },
+    ],
+  },
+  {
+    label: 'Layout & Navigation',
+    items: [
+      { label: 'Collapsible', link: '/components/collapsible' },
+      { label: 'Breadcrumb', link: '/components/breadcrumb' },
+      { label: 'Navigation Menu', link: '/components/navigation-menu' },
+      { label: 'Pagination', link: '/components/pagination' },
+      { label: 'Resizable', link: '/components/resizable' },
+      { label: 'Scroll Area', link: '/components/scroll-area' },
+      { label: 'Sidebar', link: '/components/sidebar' },
+      { label: 'Tabs', link: '/components/tabs' },
+      { label: 'Layout Simple', link: '/components/layout-simple' },
+    ],
+  },
+  {
+    label: 'Data Display',
+    items: [
+      { label: 'Card', link: '/components/card' },
+      { label: 'Avatar', link: '/components/avatar' },
+      { label: 'Basic Alert', link: '/components/basic-alert' },
+      { label: 'Table', link: '/components/table' },
+      { label: 'Kbd', link: '/components/kbd' },
+      { label: 'Separator', link: '/components/separator' },
+      { label: 'Progress', link: '/components/progress' },
+      { label: 'Skeleton', link: '/components/skeleton' },
+      { label: 'Sonner', link: '/components/sonner' },
+      { label: 'Empty', link: '/components/empty' },
+      { label: 'Item', link: '/components/item' },
+      { label: 'Typography', link: '/components/typography' },
+      { label: 'Aspect Ratio', link: '/components/aspect-ratio' },
+      { label: 'Carousel', link: '/components/carousel' },
+    ],
+  },
+  {
+    label: 'Misc',
+    items: [{ label: 'Searchable Multiselect', link: '/components/searchable-multiselect' }],
+  },
+];
 
 @Component({
   selector: 'app-root',
@@ -31,14 +132,21 @@ export class App {
 
   iconPath = 'assets/logo.png';
 
-  leftMenus = [
-    { label: 'Button', link: '/components/button', class: 'tw:font-bold' },
-    { label: 'Badge', link: '/components/badge', class: 'tw:font-bold' },
-    { label: 'Alert', link: '/components/alert', class: 'tw:font-bold' },
-    { label: 'Accordion', link: '/components/accordion', class: 'tw:font-bold' },
-    { label: 'Spinner', link: '/components/spinner', class: 'tw:font-bold' },
-    { label: 'Form Field', link: '/components/form-field', class: 'tw:font-bold' },
+  // Use groups (rendered as hover-dropdowns in the header) for full 70 item inventory.
+  leftMenuGroups: MenuGroup[] = COMPONENT_GROUPS;
+
+  // Quick-access left menus that always appear in the header (regardless of grouping).
+  leftMenus: MenuItem[] = [
+    { label: 'Home', link: '/' },
+    { label: 'Components', link: '/components/button', class: 'tw:font-bold' },
   ];
+
+  // Category shortcuts rendered in a top menu bar below the header.
+  topMenus: MenuItem[] = COMPONENT_GROUPS.map((g) => ({
+    label: g.label ?? 'Other',
+    link: g.items[0]?.link ?? '/components/button',
+    class: 'tw:font-medium',
+  }));
 
   rightMenus = [{ label: 'Sign Out', action: () => alert('Signed out'), class: 'tw:bg-yellow-200' }];
 

--- a/packages/angular/projects/layout-simple/src/lib/layout.html
+++ b/packages/angular/projects/layout-simple/src/lib/layout.html
@@ -121,11 +121,28 @@
   </header>
 
   @let _topMenus = leftMenus().concat(rightMenus()); @let _userMenus = userMenus(); @let _leftMenuGroups =
-  leftMenuGroups();
+  leftMenuGroups(); @let _topMenuItems = topMenus();
+
+  <!-- Top menus (desktop) -->
+  @if (_topMenuItems.length > 0) {
+  <nav [class]="_computedTopClass()">
+    @for (item of _topMenuItems; track item.label) { @if (item.link) {
+    <a [routerLink]="item.link" [class]="hlm(_computedTopLinkClass(), item.class || '')"> {{ item.label }} </a>
+    } @else {
+    <button type="button" (click)="item.action?.()" [class]="hlm(_computedTopLinkClass(), item.class || '')">
+      {{ item.label }}
+    </button>
+    } }
+  </nav>
+  }
 
   <!-- Mobile menu -->
   @if (isMobile() && mobileMenuOpen) {
   <div class="tw:w-full tw:border-none">
+    @if (_topMenuItems.length > 0) {
+    <eg-layout-simple-mobile-menu-group [items]="_topMenuItems" (itemClick)="toggleMobileMenu()" />
+    }
+
     <eg-layout-simple-mobile-menu-group [items]="_topMenus" (itemClick)="toggleMobileMenu()" />
 
     @for (group of _leftMenuGroups; track $index) { @if (group.items && group.items.length > 0) {

--- a/packages/angular/projects/layout-simple/src/lib/layout.ts
+++ b/packages/angular/projects/layout-simple/src/lib/layout.ts
@@ -61,6 +61,7 @@ export class EgLayoutSimple<TItem, TParams extends object = { search: string }> 
   leftMenus = input<MenuItem[]>([]);
   leftMenuGroups = input<MenuGroup[]>([]);
   rightMenus = input<MenuItem[]>([]);
+  topMenus = input<MenuItem[]>([]);
   userMenus = input<UserMenuSection[]>([]);
   logo = input<string>('assets/logo.png');
   logoLink = input<string>('/');
@@ -73,10 +74,12 @@ export class EgLayoutSimple<TItem, TParams extends object = { search: string }> 
   /** Container class inputs */
   leftMenuClass = input<ClassValue>('', { alias: 'leftClass' });
   rightMenuClass = input<ClassValue>('', { alias: 'rightClass' });
+  topMenuClass = input<ClassValue>('', { alias: 'topClass' });
 
   /** Link/button base class inputs */
   leftLinkClass = input<ClassValue>('', { alias: 'leftLinkClass' });
   rightLinkClass = input<ClassValue>('', { alias: 'rightLinkClass' });
+  topLinkClass = input<ClassValue>('', { alias: 'topLinkClass' });
 
   searchEnabled = input<boolean>(false);
   loading = input<boolean>(false);
@@ -103,10 +106,22 @@ export class EgLayoutSimple<TItem, TParams extends object = { search: string }> 
   /** Computed merged classes for containers */
   protected readonly _computedLeftClass = computed(() => hlm(commonLinkGroupClasses, this.leftMenuClass()));
   protected readonly _computedRightClass = computed(() => hlm(commonLinkGroupClasses, this.rightMenuClass()));
+  protected readonly _computedTopClass = computed(() =>
+    hlm(
+      'tw:flex tw:flex-wrap tw:items-center tw:gap-x-4 tw:gap-y-1 tw:px-4 tw:py-2 tw:bg-gray-50 tw:border-b tw:border-gray-200',
+      this.topMenuClass(),
+    ),
+  );
 
   /** Computed merged classes for link/button elements */
   protected readonly _computedLeftLinkClass = computed(() => hlm(commonLinkClasses, this.leftLinkClass()));
   protected readonly _computedRightLinkClass = computed(() => hlm(commonLinkClasses, this.rightLinkClass()));
+  protected readonly _computedTopLinkClass = computed(() =>
+    hlm(
+      'tw:text-secondary tw:visited:text-secondary tw:hover:text-primary tw:cursor-pointer tw:no-underline tw:text-sm',
+      this.topLinkClass(),
+    ),
+  );
 
   mobileMenuItemClass = commonLinkClasses;
 


### PR DESCRIPTION
## Summary

This change extends `EgLayoutSimple` with a new top menu area and updates the standard Angular example to use the new navigation capabilities.

## What changed

### Layout primitive updates
- Added a `topMenus` input to `EgLayoutSimple`.
- Added styling inputs for the new top menu container and links.
- Rendered top-level menu links in the desktop layout.
- Included the top menu group in the mobile menu so the same navigation remains available on smaller screens.

### Standard example updates
- Reworked the standard example navigation data to include grouped component menus.
- Added quick-access left menus and top menu shortcuts.
- Wired the example template to pass the new `leftMenuGroups` and `topMenus` inputs into `EgLayoutSimple`.

## Notes

- The layout change is reusable and enables other apps to provide a dedicated top navigation bar.
- The example now showcases the full grouped menu inventory instead of a small flat list of items.

## Files changed
- `packages/angular/projects/layout-simple/src/lib/layout.ts`
- `packages/angular/projects/layout-simple/src/lib/layout.html`
- `packages/angular/@examples/standard/src/app/app.ts`
- `packages/angular/@examples/standard/src/app/app.html`