### PR TITLE
Reorganize component groups in the Angular standard example

### DIFF
--- a/packages/angular/@examples/standard/src/app/app.html
+++ b/packages/angular/@examples/standard/src/app/app.html
@@ -4,7 +4,6 @@
     [sidebarTitle]="'Egose Menu'"
     [sidebarContent]="sidebarContent"
     [leftMenus]="leftMenus"
-    [leftMenuGroups]="leftMenuGroups"
     [topMenus]="topMenus"
     [rightMenus]="rightMenus"
     [userMenus]="menus"

--- a/packages/angular/@examples/standard/src/app/app.ts
+++ b/packages/angular/@examples/standard/src/app/app.ts
@@ -15,24 +15,16 @@ import { EgLayoutSimple, MenuItem, MenuGroup } from '@egose/shadcn-theme-ng/layo
 
 type Country = { name: string; code: string; flag: string };
 
-// All 70 component demos, grouped by their natural category (mirrors the sidebar in components.ts).
+// All 70 component demos, grouped by their natural category. "Existing" items are
+// merged back into the appropriate categories — there is no special "Existing" group.
 const COMPONENT_GROUPS: MenuGroup[] = [
-  {
-    label: 'Existing',
-    items: [
-      { label: 'Button', link: '/components/button' },
-      { label: 'Badge', link: '/components/badge' },
-      { label: 'Icon', link: '/components/icon' },
-      { label: 'Alert', link: '/components/alert' },
-      { label: 'Accordion', link: '/components/accordion' },
-      { label: 'Spinner', link: '/components/spinner' },
-      { label: 'Form Field', link: '/components/form-field' },
-    ],
-  },
   {
     label: 'Buttons & Indicators',
     items: [
+      { label: 'Button', link: '/components/button' },
       { label: 'Button Group', link: '/components/button-group' },
+      { label: 'Icon', link: '/components/icon' },
+      { label: 'Spinner', link: '/components/spinner' },
       { label: 'Toggle', link: '/components/toggle' },
       { label: 'Toggle Group', link: '/components/toggle-group' },
       { label: 'Switch', link: '/components/switch' },
@@ -56,6 +48,7 @@ const COMPONENT_GROUPS: MenuGroup[] = [
       { label: 'Date Picker', link: '/components/date-picker' },
       { label: 'Calendar', link: '/components/calendar' },
       { label: 'Field', link: '/components/field' },
+      { label: 'Form Field', link: '/components/form-field' },
       { label: 'Form Checkbox', link: '/components/form-checkbox' },
       { label: 'Form Date Picker', link: '/components/form-date-picker' },
       { label: 'Form Field Simple', link: '/components/form-field-simple' },
@@ -85,6 +78,7 @@ const COMPONENT_GROUPS: MenuGroup[] = [
   {
     label: 'Layout & Navigation',
     items: [
+      { label: 'Accordion', link: '/components/accordion' },
       { label: 'Collapsible', link: '/components/collapsible' },
       { label: 'Breadcrumb', link: '/components/breadcrumb' },
       { label: 'Navigation Menu', link: '/components/navigation-menu' },
@@ -99,9 +93,11 @@ const COMPONENT_GROUPS: MenuGroup[] = [
   {
     label: 'Data Display',
     items: [
+      { label: 'Alert', link: '/components/alert' },
+      { label: 'Basic Alert', link: '/components/basic-alert' },
+      { label: 'Badge', link: '/components/badge' },
       { label: 'Card', link: '/components/card' },
       { label: 'Avatar', link: '/components/avatar' },
-      { label: 'Basic Alert', link: '/components/basic-alert' },
       { label: 'Table', link: '/components/table' },
       { label: 'Kbd', link: '/components/kbd' },
       { label: 'Separator', link: '/components/separator' },
@@ -131,9 +127,6 @@ export class App {
   protected title = 'angular';
 
   iconPath = 'assets/logo.png';
-
-  // Use groups (rendered as hover-dropdowns in the header) for full 70 item inventory.
-  leftMenuGroups: MenuGroup[] = COMPONENT_GROUPS;
 
   // Quick-access left menus that always appear in the header (regardless of grouping).
   leftMenus: MenuItem[] = [


### PR DESCRIPTION
## Summary
Rework the Angular standard example navigation data so the header no longer uses a separate `Existing` group and the component inventory is redistributed into the most appropriate categories.

## What changed
- Removed the `leftMenuGroups` binding from the standard example layout template.
- Updated the component group definitions to:
  - merge former `Existing` items back into their natural categories
  - move `Accordion` into layout/navigation
  - move `Alert`, `Basic Alert`, and `Badge` into data display
  - keep button and form-related items grouped more consistently
- Removed the unused `leftMenuGroups` property from the app component.

## Notes
This change only affects the Angular example app navigation structure and keeps the underlying component links intact.